### PR TITLE
Fixed router path to simplify deployment

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -4,27 +4,27 @@ import Home from '../views/Home.vue';
 // import About from '@/src/pages/About.vue';
 
 export const routes = [
-  {
-    path: '/',
-    name: 'Home',
-    component: Home,
-  },
-  // {
-  //   path: '/about',
-  //   name: 'About Us',
-  //   component: About,
-  // },
-  // {
-  //   path: '/blog/:post',
-  //   name: 'Blog',
-  //   component: Blog,
-  // }
+	{
+		path: '/',
+		name: 'Home',
+		component: Home,
+	},
+	// {
+	//   path: '/about',
+	//   name: 'About Us',
+	//   component: About,
+	// },
+	// {
+	//   path: '/blog/:post',
+	//   name: 'Blog',
+	//   component: Blog,
+	// }
 ];
 
-// * REMOVE "/website/" FOR FILEZILLA
 const router = createRouter({
-  history: createWebHistory('/website/'), // Required for deployment
-  routes,
+	// Required for gh-pages deployment
+	history: createWebHistory(location.host == 'cutc-official.github.io' ? '/website/' : '/'),
+	routes
 });
 
 export default router;

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,5 +1,0 @@
-module.exports = {
-  publicPath: process.env.NODE_ENV === 'production'
-    ? '/website/'
-    : '/'
-}


### PR DESCRIPTION
Filezilla needs a base url of "/", whereas github pages needs "/website/". To simplifying deployment from Github pages to the release build, the base url should dynamically change.