### PR TITLE
Fixing carousels for the Testimonials & Speakers section

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "core-js": "^3.6.5",
+    "swiper": "^6.5.0",
     "vue": "^3.0.0",
     "vue-router": "^4.0.0-0",
     "vueperslides": "^3.2.0"

--- a/src/components/homePage/Speakers.vue
+++ b/src/components/homePage/Speakers.vue
@@ -20,49 +20,41 @@
 		</div>
 		
 		<div v-for="(section, sectionName) in information" :key="section">
-			<vueper-slides
-				v-if="sectionName == currentPage"
-				class="no-shadow"
-				:touchable="false"
-				:slideRatio="slideRatio"
-			>
-				<template v-slot:arrow-left>
-					<img src="../../assets/Arrow.svg" class="left-arrow arrow"/>
-				</template>
-				<template v-slot:arrow-right>
-					<img src="../../assets/Arrow.svg" class="arrow"/>
-				</template>
+			<swiper v-if="sectionName == currentPage" :loop="true" :autoHeight="true" :pagination="{ clickable: true }" navigation>
+				<!-- <img src="../../assets/Arrow.svg" class="left-arrow arrow"/> -->
+				<!-- <img src="../../assets/Arrow.svg" class="arrow"/> -->
 
-				<vueper-slide v-for="(slide, i) in section" :key="i">
-					<template v-slot:content>
-						<div class="vueperslide__content-wrapper">
-							<div class="slide-wrapper">
-								<img v-if="slide.image" :src="getImage(slide.image)" :alt="slide.name + '\'s Photo'"/>
-								<p :class="{'bold-text': sectionName == 'Events'}">
-									<i>{{ slide.content }}</i>
-									<br/>
-									<strong>{{ slide.name }}</strong>
-									{{ slide.tagLine }}
-								</p>
-							</div>
-						</div>
-					</template>
-				</vueper-slide>
-
-			</vueper-slides>
+				<swiper-slide v-for="(slide, i) in section" :key="i">
+					<div class="slide-wrapper">
+						<img class="person" v-if="slide.image" :src="getImage(slide.image)" :alt="slide.name + '\'s Photo'" />
+						<p :class="{'bold-text': sectionName == 'Events'}">
+							<i>{{ slide.content }}</i>
+							<br/>
+							<strong>{{ slide.name }}</strong>
+							{{ slide.tagLine }}
+						</p>
+					</div>
+				</swiper-slide>
+			</swiper>
 		</div>
 	</div>
 </div>
 </template>
 
 <script>
-import { VueperSlides, VueperSlide } from 'vueperslides'
-import 'vueperslides/dist/vueperslides.css'
+import SwiperCore, { Navigation, Pagination } from 'swiper';
+import { Swiper, SwiperSlide } from 'swiper/vue';
+import 'swiper/swiper-bundle.css';
 import SpeakerInfo from "../../content/speakers.json";
 
+SwiperCore.use([Navigation, Pagination]);
+
 export default {
-	components: { VueperSlides, VueperSlide },
+	components: { Swiper, SwiperSlide },
 	name: 'Speakers',
+	navigation: {
+		nextEl: '.arrow'
+	},
 	data: () => ({
 		information: SpeakerInfo,
 		currentPage: 'Speakers', // ! CONSTANT SHOULD BE DYNAMICALLY SET
@@ -137,11 +129,13 @@ export default {
 .slide-wrapper {
 	display: flex;
 	justify-content: space-evenly;
-	max-width: 70%;
+	max-width: 80%;
 }
 .slide-wrapper>img {
 	max-width: 50%;
+	height: 50%; /* hacky way of doing the aspect ratio of 1-1 */
 	margin-right: 10%;
+	margin-left: 10%;
 	border-radius: 50%;
 }
 .slide-wrapper>p {
@@ -153,17 +147,6 @@ export default {
 .bold-text {
 	font-size: 1.3em;
 }
-
-.vueperslides__bullet .default {
-	background: #FF4E4E;
-}
-.vueperslides__bullet--active .default {
-	background-color: #42b983;
-}
-.vueperslides__bullet span {
-	display: block;
-}
-
 .left-arrow {
 	transform: rotate(180deg);
 }

--- a/src/components/homePage/Speakers.vue
+++ b/src/components/homePage/Speakers.vue
@@ -20,10 +20,11 @@
 		</div>
 		
 		<div v-for="(section, sectionName) in information" :key="section">
-			<swiper v-if="sectionName == currentPage" :loop="true" :autoHeight="true" :pagination="{ clickable: true }" navigation>
-				<!-- <img src="../../assets/Arrow.svg" class="left-arrow arrow"/> -->
-				<!-- <img src="../../assets/Arrow.svg" class="arrow"/> -->
-
+			<swiper v-if="sectionName == currentPage" :loop="true" :autoHeight="true" :pagination="{ clickable: true }">
+        <div v-if="!mobileView"> 
+					<div class="swiper-button-prev"></div>
+          <div class="swiper-button-next"></div>
+				</div>
 				<swiper-slide v-for="(slide, i) in section" :key="i">
 					<div class="slide-wrapper">
 						<img class="person" v-if="slide.image" :src="getImage(slide.image)" :alt="slide.name + '\'s Photo'" />
@@ -52,13 +53,11 @@ SwiperCore.use([Navigation, Pagination]);
 export default {
 	components: { Swiper, SwiperSlide },
 	name: 'Speakers',
-	navigation: {
-		nextEl: '.arrow'
-	},
 	data: () => ({
 		information: SpeakerInfo,
 		currentPage: 'Speakers', // ! CONSTANT SHOULD BE DYNAMICALLY SET
-		slideRatio: 0
+		slideRatio: 0,
+		mobileView: false
 	}),
 	methods: {
 		getImage(pic) {
@@ -73,6 +72,7 @@ export default {
 				this.slideRatio = 2.5/1
 			else
 				this.slideRatio = window.innerHeight / window.innerWidth
+			this.mobileView = window.innerWidth <= 550
 		},
 	},
 	created() {
@@ -130,18 +130,19 @@ export default {
 	display: flex;
 	justify-content: space-evenly;
 	max-width: 80%;
+	padding-left: 10%;
 }
 .slide-wrapper>img {
 	max-width: 50%;
 	height: 50%; /* hacky way of doing the aspect ratio of 1-1 */
 	margin-right: 10%;
-	margin-left: 10%;
 	border-radius: 50%;
 }
 .slide-wrapper>p {
 	display: flex;
 	flex-direction: column;
 	text-align: start;
+  margin-bottom: 2rem;
 }
 
 .bold-text {

--- a/src/components/homePage/Testimonials.vue
+++ b/src/components/homePage/Testimonials.vue
@@ -6,7 +6,7 @@
     <template v-slot:bullet="{ active }">
       <i class="bullet" :class="active ? 'active' : ''"></i>
     </template> leaving this here because I haven't quite fiured out how to make bullets appear for mobile --> 
-    <swiper class="swiper-container" :loop="true" :autoHeight="true" :pagination="{ clickable: true }">
+    <swiper class="swiper-container" :loop="true" :autoHeight="true" :pagination="{ clickable: true }" :autoplay="{ delay: 10000 }">
       <swiper-slide
         v-for="(slide, i) in information.slides" 
         :key="i"
@@ -28,12 +28,12 @@
 </template>
 
 <script>
-import SwiperCore, { Pagination } from 'swiper';
+import SwiperCore, { Pagination, Autoplay } from 'swiper';
 import { Swiper, SwiperSlide } from 'swiper/vue';
 import 'swiper/swiper-bundle.css';
 import TestimonialInfo from "../../content/testimonials.json";
 
-SwiperCore.use(Pagination);
+SwiperCore.use([Pagination, Autoplay]);
 
 export default {
   name: 'Testimonials',

--- a/src/components/homePage/Testimonials.vue
+++ b/src/components/homePage/Testimonials.vue
@@ -1,54 +1,43 @@
 <template>
   <div id="testimonials">
-    <h2 class="headline">Hear what people have to say about CUTC!</h2>
-    <div class="testimonials-wrapper">
-      <img src="../../assets/testimonials/testimonial_building.svg" class="building" />
-      <vueper-slides 
-        class="no-shadow" 
-        :bullets="mobileView"
-        :touchable="false" 
-        :arrows="!mobileView"
-        :disableArrowsOnEdges="true"
-        :arrowsOutside="true"
-        :slideRatio="slideRatio"
-        autoplay
+    <h2>Hear what people have to say about CUTC!</h2>
+    <img src="../../assets/testimonials/testimonial_building.svg" class="building" />
+    <!-- :bullets="mobileView" :arrows="!mobileView" :slideRatio="slideRatio"
+    <template v-slot:bullet="{ active }">
+      <i class="bullet" :class="active ? 'active' : ''"></i>
+    </template> leaving this here because I haven't quite fiured out how to make bullets appear for mobile --> 
+    <swiper class="swiper-container" :loop="true" :autoHeight="true" :pagination="{ clickable: true }">
+      <swiper-slide
+        v-for="(slide, i) in information.slides" 
+        :key="i"
       >
-        <vueper-slide 
-          v-for="(slide, i) in information.slides" 
-          :key="i"
-        >
-          <template v-slot:content>
-            <div class="vueperslide__content-wrapper">
-              <div class="slide">
-                <div class="title">
-                  <img :src="getImage(slide.image)" class="person" :alt="slide.name + '\'s Photo'"/>
-                  <br/>
-                  <strong> {{ slide.name }} </strong>
-                  <br/> 
-                  <strong> {{ slide.personDescription }} </strong>
-                </div>
-                <div class="content">"{{ slide.content }}"</div>
-              </div>
-            </div>
-          </template>
-        </vueper-slide>
-        <template v-slot:bullet="{ active }">
-          <i class="bullet" :class="active ? 'active' : ''"></i>
-        </template>
-      </vueper-slides>
-    </div>
-    <br style="clear:both" />
-  </div>
+        <div class="slide slide-container">
+          <div class="title">
+            <img :src="getImage(slide.image)" class="person" :alt="slide.name + '\'s Photo'"/>
+            <br/>
+            <strong> {{ slide.name }} </strong>
+            <br/> 
+            <strong> {{ slide.personDescription }} </strong>
+          </div>
+          <div class="content">"{{ slide.content }}"</div>
+        </div>
+      </swiper-slide>
+    </swiper>
+  </div> 
+  <br style="clear:both" />
 </template>
 
 <script>
-import { VueperSlides, VueperSlide } from 'vueperslides';
-import 'vueperslides/dist/vueperslides.css';
+import SwiperCore, { Pagination } from 'swiper';
+import { Swiper, SwiperSlide } from 'swiper/vue';
+import 'swiper/swiper-bundle.css';
 import TestimonialInfo from "../../content/testimonials.json";
+
+SwiperCore.use(Pagination);
 
 export default {
   name: 'Testimonials',
-  components: { VueperSlides, VueperSlide },
+  components: { Swiper, SwiperSlide },
   data() {
     return {
       information: TestimonialInfo,
@@ -89,6 +78,14 @@ export default {
 .building {
   height: 60vh;
   float: left; 
+}
+
+.swiper-container {
+  margin-top: 10%;
+}
+
+.slide-container {
+  margin: auto;
 }
 
 .slide {

--- a/src/components/homePage/Testimonials.vue
+++ b/src/components/homePage/Testimonials.vue
@@ -86,6 +86,7 @@ export default {
 
 .slide-container {
   margin: auto;
+  padding: 2%;
 }
 
 .slide {


### PR DESCRIPTION
Fixes: #17 (high priority)

New library: https://swiperjs.com/swiper-api#pagination

In this PR I have changed the carousel library to another one to fix the problem where swiping was very poor UX especially for mobile users. New and improved look (for testimonials section):

![2021-03-23 21 28 26](https://user-images.githubusercontent.com/54586561/112240661-18a0d380-8c1f-11eb-99ae-5edbd73d0690.gif)

Issues I have:
- with this library there aren't that many demos for vue so I've been having trouble with customizing the bullets (called pagination on the api) and the arrows (called navigation)
- I have also tried to fix the fact that text is not highlightable using your mouse using this:
                  `-moz-user-select: text;
                   -khtml-user-select: text;
                   -webkit-user-select: text;
                   -ms-user-select: text;
                   user-select: text;` 
but it didn't work at all. Any thoughts/ideas on this?
- I have used a hacky way of setting the speaker photo aspect ratio to be 1:1 by setting the height