### PR TITLE
Filtering using topics and format and fixing styling on home page

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "core-js": "^3.6.5",
+    "moment-timezone": "^0.5.33",
     "swiper": "^6.5.0",
     "vue": "^3.0.0",
     "vue-router": "^4.0.0-0"

--- a/src/components/general/NavBar.vue
+++ b/src/components/general/NavBar.vue
@@ -6,7 +6,7 @@
 		<nav v-else>
 			<router-link to="/">HOME</router-link>
 			<router-link to="/speakers">SPEAKERS</router-link>
-			<!-- <router-link to="/schedule">SCHEDULE</router-link> -->
+			<router-link to="/schedule">SCHEDULE</router-link>
 			<router-link to="/blog">BLOG</router-link>
 			<register-button/>
 		</nav>
@@ -18,7 +18,7 @@
 				<nav>
 					<router-link @click="closeMenu" to="/">HOME</router-link>
 					<router-link @click="closeMenu" to="/speakers">SPEAKERS</router-link>
-					<!-- <router-link @click="closeMenu" to="/schedule">SCHEDULE</router-link> -->
+					<router-link @click="closeMenu" to="/schedule">SCHEDULE</router-link>
 					<router-link @click="closeMenu" to="/blog">BLOG</router-link>
 				</nav>
 			</div>

--- a/src/components/general/Schedule.vue
+++ b/src/components/general/Schedule.vue
@@ -29,18 +29,21 @@
 				<span style="position: absolute; display:flex; margin-left: 20%;">
 					<h4>Timezone: </h4>
 					<select id="timezones" @change="onChange($event)">
-						<!-- <option v-for="n in 26" :key="n" :value="n">{{ n - 13 }}</option> -->
-						<option value="time"> America/Toronto </option>
+						<option v-for="zone in timezones" :key="zone" :value="zone">{{ zone }}</option>
 					</select>
 				</span>
 				<hr class="top-hr" />
 			</div>
 			<div class="schedule">
-				<div v-for="(events, time) in scheduleData" :key="time">
-					<h4 class="time">{{ time }} <hr class="time-hr" /></h4>
-					<div v-for="tileInfo in events" :key="tileInfo">
-						<schedule-tile v-if="isChecked(tileInfo.topics, tileInfo.format)" class="tile" v-bind="tileInfo"/>
-					</div>
+				<div v-for="(schedule, day) in scheduleData" :key="day">
+					<span v-if="isDay(day)">
+						<div v-for="(events, time) in schedule" :key="time">
+							<h4 class="time" id="time">{{ time }}</h4> <hr class="time-hr" />
+							<div v-for="tileInfo in events" :key="tileInfo">
+								<schedule-tile v-if="isChecked(tileInfo.topics, tileInfo.format)" class="tile" v-bind="tileInfo"/>
+							</div>
+						</div>
+					</span>
 				</div>
 			</div>
 		</div>
@@ -50,6 +53,7 @@
 <script>
 import ScheduleTile from "@/components/general/ScheduleTile.vue";
 import ScheduleContent from '@/content/schedule.json';
+var moment = require('moment-timezone');
 
 export default {
 	name: 'Schedule',
@@ -69,13 +73,38 @@ export default {
 			active1: true,
 			active2: false,
 			displayTopics: true,
-			displayFormats: true
+			displayFormats: true,
+			timezones: [
+				'Africa/Lagos',
+				'America/Argentina/Rio_Gallegos',
+				'America/Buenos_Aires',
+				'America/Chicago',
+				'America/Costa_Rica',
+				'America/Detroit',
+				'America/Edmonton',
+				'America/Halifax',
+				'America/Jamaica',
+				'America/Los_Angeles',
+				'America/Montreal',
+				'America/Sao_Paulo',
+				'America/Toronto',
+				'Asia/Beirut',
+				'Asia/Dubai',
+				'Asia/Qatar',
+				'Atlantic/Bermuda',
+				'Australia/Melbourne',
+				'Brazil/East',
+				'Canada/Central',
+				'Canada/Eastern',
+				'Europe/Amsterdam',
+			],
 		}
 	},
 	methods: {
 		onChange(event) {
-			console.log(event.target.value);
-			// var time = moment()
+			const time = document.getElementById("time");
+			const date = (moment(time.innerHTML, 'hh:mm')).toDate()
+			time.innerHTML = moment.tz(date, event.target.value).format("hh:mm")
 		},
 		isChecked(topics, format) {
 			if(this.checkedTopics.length || this.checkedFormats.length ){
@@ -83,16 +112,26 @@ export default {
 			}
 			return true
 		},
+		isDay(day){
+			if(this.active1 && day == "July 24"){
+				return true
+			} else if (this.active2 && day == "July 25"){
+				return true
+			}
+			return false
+		}
 	},
 	beforeMount() {
 		let topics = []
 		let formats = []
 		for(let i in this.scheduleData){
 			for(let j in this.scheduleData[i]){
-				for(let k in this.scheduleData[i][j]["topics"]){
-					topics.push(this.scheduleData[i][j]["topics"][k])
+				for(let k in this.scheduleData[i][j]){
+					for(let l in this.scheduleData[i][j][k]["topics"]){
+						topics.push(this.scheduleData[i][j][k]["topics"][l])
+					}
+					formats.push(this.scheduleData[i][j][k]["format"])
 				}
-				formats.push(this.scheduleData[i][j]["format"])
 			}
 		}
 		this.allTopics = [...new Set(topics)]
@@ -154,6 +193,7 @@ h4 {
 
 .time {
 	margin-top: 2%;
+	display: inline;
 }
 
 .top {

--- a/src/components/general/Schedule.vue
+++ b/src/components/general/Schedule.vue
@@ -1,46 +1,50 @@
 <template>
 	<router-link v-if="link" to="/schedule">View full schedule ></router-link>
-	<div class="sidebar">
-		<h4 class="word">Topics <img :class="displayTopics ? 'arrow' : 'arrow-flipped'" src="@/assets/misc/CloseArrow.svg" @click="displayTopics = !displayTopics"></h4>
-		<span v-if="displayTopics">
-			<div style="color: black;" v-for="i in allTopics" :key="i">
-				<input type="checkbox" :id="i" :value="i" v-model="checkedTopics" class="checkbox">
-				<label for="i" class="checkboxText">{{ i }}</label>
-				<br>
-			</div>
-		</span>
-		<hr class="sidebar-hr" />
+	<span style="display: flex;">
+		<div class="sidebar">
+			<h4 class="word">Topics <img :class="displayTopics ? 'arrow' : 'arrow-flipped'" src="@/assets/misc/CloseArrow.svg" @click="displayTopics = !displayTopics"></h4>
+			<span v-if="displayTopics">
+				<div style="color: black;" v-for="i in allTopics" :key="i">
+					<input type="checkbox" :id="i" :value="i" v-model="checkedTopics" class="checkbox">
+					<label for="i" class="checkboxText">{{ i }}</label>
+					<br>
+				</div>
+			</span>
+			<hr class="sidebar-hr" />
 
-		<h4 class="word">Format <img :class="displayFormats ? 'arrow' : 'arrow-flipped'" src="@/assets/misc/CloseArrow.svg" alt="" @click="displayFormats = !displayFormats"></h4>
-		<span v-if="displayFormats">
-			<div style="color: black;" v-for="i in allFormats" :key="i">
-				<input type="checkbox" :id="i" :value="i" v-model="checkedFormats" class="checkbox">
-				<label for="i" class="checkboxText">{{ i }}</label>
-				<br>
-			</div>
-		</span>
-	</div>
-	<div>
-		<div class="top">
-			<span :class="active1 ? 'dateButton-active' : 'dateButton'" @click="active1 = true, active2 = false">JULY 24</span>
-			<span :class="active2 ? 'dateButton-active': 'dateButton'" @click="active2 = true, active1 = false">JULY 25</span>
-		<!-- <span style="position: absolute; display: inline;">
-			<h4>Timezone: </h4>
-			<select id="timezones" @change="onChange($event)">
-				<option v-for="n in 26" :key="n" :value="n">{{ n - 13 }}</option>
-			</select>
-		</span> -->
-			<hr class="top-hr" />
+			<h4 class="word">Format <img :class="displayFormats ? 'arrow' : 'arrow-flipped'" src="@/assets/misc/CloseArrow.svg" alt="" @click="displayFormats = !displayFormats"></h4>
+			<span v-if="displayFormats">
+				<div style="color: black;" v-for="i in allFormats" :key="i">
+					<input type="checkbox" :id="i" :value="i" v-model="checkedFormats" class="checkbox">
+					<label for="i" class="checkboxText">{{ i }}</label>
+					<br>
+				</div>
+			</span>
 		</div>
-		<div class="schedule">
-			<div v-for="(events, time) in scheduleData" :key="time">
-				<h4 class="time">{{ time }} <hr class="time-hr" /></h4>
-				<div v-for="tileInfo in events" :key="tileInfo">
-					<schedule-tile class="tile" v-bind="tileInfo"/>
+
+		<div>
+			<div class="top">
+				<span :class="active1 ? 'dateButton-active' : 'dateButton'" @click="active1 = true, active2 = false">JULY 24</span>
+				<span :class="active2 ? 'dateButton-active': 'dateButton'" @click="active2 = true, active1 = false">JULY 25</span>
+				<span style="position: absolute; display:flex; margin-left: 20%;">
+					<h4>Timezone: </h4>
+					<select id="timezones" @change="onChange($event)">
+						<!-- <option v-for="n in 26" :key="n" :value="n">{{ n - 13 }}</option> -->
+						<option value="time"> America/Toronto </option>
+					</select>
+				</span>
+				<hr class="top-hr" />
+			</div>
+			<div class="schedule">
+				<div v-for="(events, time) in scheduleData" :key="time">
+					<h4 class="time">{{ time }} <hr class="time-hr" /></h4>
+					<div v-for="tileInfo in events" :key="tileInfo">
+						<schedule-tile v-if="isChecked(tileInfo.topics, tileInfo.format)" class="tile" v-bind="tileInfo"/>
+					</div>
 				</div>
 			</div>
 		</div>
-	</div>
+	</span>
 </template>
 
 <script>
@@ -68,16 +72,18 @@ export default {
 			displayFormats: true
 		}
 	},
-	// methods: {
-	// 	onChange(event) {
-	// 		console.log(event.target.value);
-	// 		const dateString = '2019-04-17 05:20:37';
-	// 		const localDate = new Date(`${dateString} UTC${event.target.value}:00`);
-	// 		console.log(localDate)
-	// 		this.time = localDate
-	// 		console.log(this.time)
-	// 	},
-	// },
+	methods: {
+		onChange(event) {
+			console.log(event.target.value);
+			// var time = moment()
+		},
+		isChecked(topics, format) {
+			if(this.checkedTopics.length || this.checkedFormats.length ){
+				return ((this.checkedFormats.includes(format)) || topics.some(topic => (this.checkedTopics.includes(topic))))
+			}
+			return true
+		},
+	},
 	beforeMount() {
 		let topics = []
 		let formats = []
@@ -119,9 +125,9 @@ h4 {
 
 .top-hr {
 	position: absolute;
-	width: 78%;
+	width: 70%;
 	margin-top: 2%;
-	margin-left: 370px;
+	margin-left: -49px;
 	border: 2px solid #CCCCCC;
 }
 
@@ -174,8 +180,8 @@ h4 {
 }
 
 .schedule {
-	margin-top: 5%;
-	margin-left: 25%;
+	margin-top: 12%;
+	margin-left: 15%;
 }
 
 .tile {

--- a/src/content/schedule.json
+++ b/src/content/schedule.json
@@ -1,33 +1,68 @@
 {
-	"8:00": [
-		{
-			"title": "title 1",
-			"description": "desc",
-			"format": "workshop",
-			"location": "",
-			"timestamp": "",
-			"topics": ["t1", "t2"],
-			"speakers": [""]
-		},
-		{
-			"title": "",
-			"description": "",
-			"format": "talk",
-			"location": "",
-			"timestamp": "",
-			"topics": ["t3", "t4"],
-			"speakers": [""]
-		}
-	],
-	"9:30": [
-		{
-			"title": "",
-			"description": "",
-			"format": "",
-			"location": "",
-			"timestamp": "",
-			"topics": ["t3", "t2"],
-			"speakers": [""]
-		}
-	]
+	"July 24": {
+		"8:00": [
+			{
+				"title": "title 1",
+				"description": "desc",
+				"format": "workshop",
+				"location": "",
+				"timestamp": "",
+				"topics": ["t1", "t2"],
+				"speakers": [""]
+			},
+			{
+				"title": "",
+				"description": "",
+				"format": "talk",
+				"location": "",
+				"timestamp": "",
+				"topics": ["t3", "t4"],
+				"speakers": [""]
+			}
+		],
+		"9:30": [
+			{
+				"title": "",
+				"description": "",
+				"format": "",
+				"location": "",
+				"timestamp": "",
+				"topics": ["t3", "t2"],
+				"speakers": [""]
+			}
+		]
+	},
+	"July 25": {
+		"10:00": [
+			{
+				"title": "title 1",
+				"description": "desc",
+				"format": "workshop",
+				"location": "",
+				"timestamp": "",
+				"topics": ["t1", "t2"],
+				"speakers": [""]
+			},
+			{
+				"title": "",
+				"description": "",
+				"format": "talk",
+				"location": "",
+				"timestamp": "",
+				"topics": ["t3", "t4"],
+				"speakers": [""]
+			}
+		],
+		"11:30": [
+			{
+				"title": "",
+				"description": "",
+				"format": "",
+				"location": "",
+				"timestamp": "",
+				"topics": ["t3", "t2"],
+				"speakers": [""]
+			}
+		]
+	}
 }

--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -5,18 +5,20 @@
 		<hero />
 	</div>
 
-	<div class="home-content">
-		<about />
-		<speakers :limit="8" />
-		<h4 class="schedule-placeholder">Schedule coming soon!</h4>
-		<!-- <schedule :link="true" /> -->
-		<testimonials />
-		<sponsorship />
-		<blog :limit="6" />
-		<faq />
-		<contributors />
-	</div>
-	<bottom />
+		<div class="home-content">
+			<about />
+			<speakers :limit="6" />
+			<!-- <h4 class="schedule-placeholder">Schedule coming soon!</h4> -->
+			<div style="margin: 2rem; display: block;">
+				<schedule :link="true" />
+			</div>
+			<testimonials />
+			<sponsorship />
+			<blog :limit="6" />
+			<faq />
+			<contributors />
+		</div>
+		<bottom />
 	</span>
 </template>
 
@@ -25,7 +27,7 @@ import NavBar from "@/components/general/NavBar.vue";
 import Hero from "@/components/homePage/Hero.vue";
 import About from "@/components/homePage/About.vue";
 import Speakers from "@/components/general/Speakers.vue";
-// import Schedule from "@/components/general/Schedule.vue";
+import Schedule from "@/components/general/Schedule.vue";
 import Testimonials from "@/components/homePage/Testimonials.vue";
 import Sponsorship from "@/components/homePage/Sponsorship.vue";
 import Blog from "@/components/general/Blog.vue";
@@ -36,18 +38,18 @@ import Bottom from "@/components/general/Footer.vue";
 export default {
 	name: "Home",
 	components: {
-	NavBar,
-	Hero,
-	About,
-	Speakers,
-	// Schedule,
-	Testimonials,
-	Sponsorship,
-	Blog,
-	Faq,
-	Contributors,
-	Bottom,
-	},
+		NavBar,
+		Hero,
+		About,
+		Speakers,
+		Schedule,
+		Testimonials,
+		Sponsorship,
+		Blog,
+		Faq,
+		Contributors,
+		Bottom
+	}
 };
 </script>
 


### PR DESCRIPTION
## what this PR does
- fixes the look of the schedule in the home page 
- now you can filter through the schedule tiles using the topics and the format and the date 
- can change timezones (only works for 1st values since I used `getElementById` but I know there's a better way to dynamically update the variable in vue)